### PR TITLE
Change kwargs type to str

### DIFF
--- a/pyflow/nodes.py
+++ b/pyflow/nodes.py
@@ -150,7 +150,7 @@ class Node(Base):
             variables(Variable_): An attribute for setting an **ecFlow** variable.
             zombies(Zombies_): An attribute that defines how a zombie should be handled in an automated fashion.
             events(Event_): An attribute for declaring an action that a task can trigger while it is running.
-            **kwargs(dict): Accept extra keyword arguments as variables to be set on the node.
+            **kwargs(str): Accept extra keyword arguments as variables to be set on the node.
         """
 
         super().__init__(name)
@@ -808,7 +808,7 @@ class Family(Node):
             variables(Variable_): An attribute for setting an **ecFlow** variable.
             zombies(Zombies_): An attribute that defines how a zombie should be handled in an automated fashion.
             events(Event_): An attribute for declaring an action that a task can trigger while it is running.
-            **kwargs(dict): Accept extra keyword arguments as variables to be set on the family.
+            **kwargs(str): Accept extra keyword arguments as variables to be set on the family.
 
         Example::
 
@@ -890,7 +890,7 @@ class AnchorFamily(AnchorMixin, Family):
             variables(Variable_): An attribute for setting an **ecFlow** variable.
             zombies(Zombies_): An attribute that defines how a zombie should be handled in an automated fashion.
             events(Event_): An attribute for declaring an action that a task can trigger while it is running.
-            **kwargs(dict): Accept extra keyword arguments as variables to be set on the anchor family.
+            **kwargs(str): Accept extra keyword arguments as variables to be set on the anchor family.
 
         Example::
 
@@ -947,7 +947,7 @@ class Suite(AnchorMixin, Node):
             variables(Variable_): An attribute for setting an **ecFlow** variable.
             zombies(Zombies_): An attribute that defines how a zombie should be handled in an automated fashion.
             events(Event_): An attribute for declaring an action that a task can trigger while it is running.
-            **kwargs(dict): Accept extra keyword arguments as variables to be set on the suite.
+            **kwargs(str): Accept extra keyword arguments as variables to be set on the suite.
 
         Example::
 
@@ -1097,7 +1097,7 @@ class Task(Node):
             variables(Variable_): An attribute for setting an **ecFlow** variable.
             zombies(Zombies_): An attribute that defines how a zombie should be handled in an automated fashion.
             events(Event_): An attribute for declaring an action that a task can trigger while it is running.
-            **kwargs(dict): Accept extra keyword arguments as variables to be set on the task.
+            **kwargs(str): Accept extra keyword arguments as variables to be set on the task.
 
         Example::
 


### PR DESCRIPTION
I think kwargs is a dict, but either my IDE and/or mypy recognize it already as a dict, and in the pydoc comments we can put just the value of the type stored in it (my guess & from [this mypy page](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html#when-you-re-puzzled-or-when-things-are-complicated)).

Here's what it looks like whenever I use an extra variable in a family:

![Screenshot from 2022-11-29 16-39-17](https://user-images.githubusercontent.com/304786/204576598-937b449d-081e-4b78-af7d-d465396543d4.png)

Hovering the mouse, the warning shown says “Expected type 'dict', got 'str' instead”. After this change:

![Screenshot from 2022-11-29 16-39-49](https://user-images.githubusercontent.com/304786/204576721-0b93a514-a32b-4393-b7bd-1bdb201fb492.png)

I was going over other places where kwargs is used, but I found one where it was actually using an object that extends `Script`. I was inclined to use `Any` there, but preferred to first raise this PR/issue, and see what others prefer :+1: 

Thanks!
-Bruno

