### PR TITLE
Hotfix/file_resource_script_generation

### DIFF
--- a/pyflow/nodes.py
+++ b/pyflow/nodes.py
@@ -1188,11 +1188,7 @@ class Suite(AnchorMixin, Node):
 
         for t in node.all_tasks:
             script, includes = t.generate_script()
-            try:
-                target.deploy_task(t.deploy_path, script, includes)
-            except Exception as e:
-                print(f"\nERROR when deploying task: {t.fullname}\n")
-                raise (e)
+            target.deploy_task(t.deploy_path, script, includes)
         for f in node.all_families:
             manual = self.generate_stub(f.manual)
             if manual:

--- a/pyflow/resource.py
+++ b/pyflow/resource.py
@@ -81,30 +81,7 @@ class Resource(Task):
 
         return []
 
-    def install_file_stub(self, target):
-        """
-        Installs any data associated with the resource object that is going to be deployed from the **ecFlow** server.
-
-        Parameters:
-            target(Deployment): The target deployment where the resource data should be installed.
-        """
-
-        """
-        n.b. If a resource does not need to save data at deployment time, it should not do so (e.g. WebResource)
-        """
-        # Install path is for the suite, so we don't need to include the suite name
-        assert self.fullname.count("/") > 1
-        subpath = self.fullname[self.fullname.find("/", 1) + 1 :]
-
-        self._server_filename = os.path.join(
-            target.files_install_path(), subpath, self.name
-        )
-
-        super().install_file_stub(target)
-
-        self.save_data(target, self._server_filename)
-
-    def build_script(self):
+    def generate_script(self):
         """
         Returns the installer script for the data resource.
 
@@ -129,7 +106,7 @@ class Resource(Task):
         for h in self._hosts:
             lines += h.copy_file_to(self._server_filename, self.location()).split("\n")
 
-        return lines
+        return lines, []
 
     def location(self):
         """
@@ -207,9 +184,8 @@ class FileResource(Resource):
     """
 
     def __init__(self, name, hosts, source_file):
-        self._source = source_file
-
         super().__init__(name, hosts)
+        self._server_filename = source_file
 
     def md5(self):
         """
@@ -231,7 +207,7 @@ class FileResource(Resource):
             The resource data.
         """
 
-        with open(self._source, "rb") as f:
+        with open(self._server_filename, "rb") as f:
             return f.read()
 
     def save_data(self, target, filename):

--- a/pyflow/resource.py
+++ b/pyflow/resource.py
@@ -106,7 +106,7 @@ class Resource(Task):
         for h in self._hosts:
             lines += h.copy_file_to(self._server_filename, self.location()).split("\n")
 
-        return lines, [] 
+        return lines, []
 
     def location(self):
         """

--- a/pyflow/resource.py
+++ b/pyflow/resource.py
@@ -106,7 +106,7 @@ class Resource(Task):
         for h in self._hosts:
             lines += h.copy_file_to(self._server_filename, self.location()).split("\n")
 
-        return lines, []
+        return lines, [] 
 
     def location(self):
         """
@@ -160,6 +160,8 @@ class DataResource(Resource):
             target(Deployment): The deployment target.
             filename(str): The filename for the resource data.
         """
+
+        self._server_filename = filename
 
         """
         Resources don't all need to save data at generation time

--- a/tests/file_resource.txt
+++ b/tests/file_resource.txt
@@ -1,0 +1,1 @@
+# Example for a file resource

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1,0 +1,44 @@
+from os import path
+from os.path import join
+
+from pyflow import FileResource, Notebook, Suite
+from pyflow.host import SSHHost
+
+
+def test_file_resource():
+
+    resouces_directory = "/resources_directory"
+
+    sshhost_1 = SSHHost("example_ssh_host_1", resources_directory=resouces_directory)
+    sshhost_2 = SSHHost("example_ssh_host_2", resources_directory=resouces_directory)
+    host_set = [sshhost_1, sshhost_2]
+
+    source_file = path.join(path.dirname(path.abspath(__file__)), "file_resource.txt")
+    name = "file_resource"
+
+    with Suite("s", host=sshhost_1) as s:
+        s.resource_file = FileResource(name, hosts=host_set, source_file=source_file)
+
+    # Check that variables are set correctly
+    assert s.resource_file.host == sshhost_1
+    assert s.resource_file.location() == join(
+        str(sshhost_1.resources_directory), s.name, name
+    )
+    assert s.resource_file._hosts == host_set
+
+    # Check that the deployment scripts have been generated
+    s.check_definition()
+    s.generate_node()
+
+    s.deploy_suite(target=Notebook)
+
+    generate_file_resource_script_lines, _ = s.resource_file.generate_script()
+    assert any(sshhost_1.name in s for s in generate_file_resource_script_lines)
+    assert any(sshhost_2.name in s for s in generate_file_resource_script_lines)
+
+
+if __name__ == "__main__":
+
+    import pytest
+
+    pytest.main(path.abspath(__file__))


### PR DESCRIPTION
When working with marsflow I encountered problems with the `pf.FileResource` class which was mainly due to the reason that the internals of the resource class have changed.

I enabled moved the assignment of the `server_filename` to the constructor of the `pf.FileResource` class and adjusted other occurrences. 

In case my changes broke the intended architecture, feel free to comment.