### PR TITLE
adding support for ecflow generated variables

### DIFF
--- a/pyflow/attributes.py
+++ b/pyflow/attributes.py
@@ -295,6 +295,28 @@ class Variable(Exportable):
         ecflow_parent.add_variable(str(self.name), str(self.value))
 
 
+class GeneratedVariable(Exportable):
+    """
+    An attribute for referencing an **ecFlow** generated variable.
+    The variable value will be generated automatically by ecFlow.
+
+    Parameters:
+        name(str): The name of the variable.
+
+    Example::
+
+        GeneratedVariable('FOO')
+    """
+
+    def __init__(self, name):
+        if not is_variable(name):
+            raise ValueError("'{}' is not a valid variable name".format(name))
+        super().__init__(name)
+
+    def _build(self, *args, **kwargs):
+        return
+
+
 class Edit:
     """
     An attribute for setting multiple **ecFlow** variables.

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -531,6 +531,16 @@ class TestRepeats:
         s.check_definition()
 
 
+def test_generated_variables():
+    with pyflow.Suite("s") as s:
+        with pyflow.Family("f") as f:
+            t = pyflow.Task("t")
+
+    assert [var in s.all_exportables for var in s.suite_gen_vars]
+    assert [var in f.all_exportables for var in f.family_gen_vars]
+    assert [var in t.all_exportables for var in t.task_gen_vars]
+
+
 if __name__ == "__main__":
     from os import path
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -533,11 +533,12 @@ class TestRepeats:
 
 def test_generated_variables():
     with pyflow.Suite("s") as s:
-        with pyflow.Family("f") as f:
+        with pyflow.Family("f", generated_variables=["MYVAR"]) as f:
             t = pyflow.Task("t")
 
     assert [var in s.all_exportables for var in s.suite_gen_vars]
     assert [var in f.all_exportables for var in f.family_gen_vars]
+    assert "MYVAR" in f.all_exportables
     assert [var in t.all_exportables for var in t.task_gen_vars]
 
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -16,7 +16,7 @@ def test_triggers_and():
 
 def test_all_complete():
     with pyflow.Suite("s") as s:
-        with pyflow.Family("f1") as f:
+        with pyflow.Family("f1"):
             with pyflow.Family("f1f1"):
                 pyflow.Task("t1")
                 pyflow.Task("t2")

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -33,11 +33,6 @@ def test_all_complete():
         pyflow.all_complete(s.executable_children)
     )
 
-    assert (
-        "(((/s/f1/f1f1 eq complete) and (/s/f1/f1f2 eq complete)) and (/s/f1/t5 eq complete))"
-        == str(pyflow.all_complete(f.children))
-    )
-
 
 def test_trigger_chains():
     """

--- a/tests/test_families.py
+++ b/tests/test_families.py
@@ -35,7 +35,7 @@ def test_children():
     children = f.children
     names = set([c.name for c in children])
 
-    assert names == {"limit1", "VARIABLE1", "f2", "t4", "t5"}
+    assert names == {"limit1", "VARIABLE1", "f2", "t4", "t5", "FAMILY", "FAMILY1"}
 
 
 def test_executable_children():

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -295,7 +295,6 @@ def test_troika_host():
 
 
 def test_troika_host_options():
-
     host = pyflow.TroikaHost(
         name="test_host",
         user="test_user",


### PR DESCRIPTION
Generated variables are hardcoded and only available at the Node level (not attributes like repeat), we'll get them from ecflow in the future but it requires to fix the python interface in ecflow (thanks @marcosbento for helping with this).