### PR TITLE
Enable node-level partial deployment

### DIFF
--- a/pyflow/nodes.py
+++ b/pyflow/nodes.py
@@ -1138,7 +1138,7 @@ class Suite(AnchorMixin, Node):
 
         return super().find_node(subpath)
 
-    def deploy_suite(self, target=FileSystem, **options):
+    def deploy_suite(self, target=FileSystem, node=None, **options):
         """
         Deploys suite and its components.
 
@@ -1154,14 +1154,15 @@ class Suite(AnchorMixin, Node):
         assert not self._extern, "Attempting to deploy extern node not permitted"
 
         target = target(self, **options)
-        for t in self.all_tasks:
+        node = node if node is not None else self
+        for t in node.all_tasks:
             script, includes = t.generate_script()
             try:
                 target.deploy_task(t.deploy_path, script, includes)
             except RuntimeError:
                 print(f"\nERROR when deploying task: {t.fullname}\n")
                 raise
-        for f in self.all_families:
+        for f in node.all_families:
             manual = self.generate_stub(f.manual)
             if manual:
                 target.deploy_manual(f.manual_path, manual)

--- a/pyflow/nodes.py
+++ b/pyflow/nodes.py
@@ -1144,6 +1144,7 @@ class Suite(AnchorMixin, Node):
 
         Parameters:
             target(Deployment): Deployment target for the suite.
+            node(str): Path to node to limit deployment to a family/task.
             **options(dict): Accept extra keyword arguments as deployment options.
 
         Returns:
@@ -1154,7 +1155,8 @@ class Suite(AnchorMixin, Node):
         assert not self._extern, "Attempting to deploy extern node not permitted"
 
         target = target(self, **options)
-        node = node if node is not None else self
+        node = self.find_node(node) if node is not None else self
+
         for t in node.all_tasks:
             script, includes = t.generate_script()
             try:

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -31,7 +31,7 @@ def test_deploy_filesystem(tmpdir, ECF_FILES):
     # partial deployment
     t1.script = "echo new"
     t2.script = "echo new"
-    s.deploy_suite(node=s.f2)
+    s.deploy_suite(node="f2")
     with open(f1) as f:
         # shouldn't not be updated
         assert "echo foo" in f.read()

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -11,11 +11,11 @@ def test_deploy_filesystem(tmpdir, ECF_FILES):
     files = path.join(str(tmpdir), ECF_FILES)
     with pyflow.Suite("s", ECF_HOME=str(tmpdir), ECF_FILES=files) as s:
         with pyflow.Family("f1"):
-            with pyflow.Task("t") as t:
-                t.script = "echo foo"
+            with pyflow.Task("t") as t1:
+                t1.script = "echo foo"
         with pyflow.Family("f2"):
-            with pyflow.Task("t2") as t:
-                t.script = "echo bar"
+            with pyflow.Task("t2") as t2:
+                t2.script = "echo bar"
 
     s.deploy_suite()
     s.deploy_suite(target=pyflow.Notebook)
@@ -27,6 +27,16 @@ def test_deploy_filesystem(tmpdir, ECF_FILES):
     assert path.exists(f2)
     with open(f2) as f:
         assert "echo bar" in f.read()
+
+    # partial deployment
+    t1.script = "echo new"
+    t2.script = "echo new"
+    s.deploy_suite(node=s.f2)
+    with open(f1) as f:
+        # shouldn't not be updated
+        assert "echo foo" in f.read()
+    with open(f2) as f:
+        assert "echo new" in f.read()
 
 
 def test_move_node(tmpdir):


### PR DESCRIPTION
Large suites can take a long-time to deploy making fixes to individual scripts more time-consuming than necessary. This change enables partial deployment of individual nodes (families or tasks). This has been requested by operations many times and would improve operational use of pyflow suites.

NB: this could be further refactored by moving the `deploy_suite` method to `Node.deploy` and do the selection of which node to deploy outside of pyflow (e.g. `suite.find_node("suite/family/task").deploy()`).