### PR TITLE
Feature/be explicit about supported time format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist
 pyflow.slides.html
 course/scratch/*
 docs/_build
+_version.py

--- a/pyflow/attributes.py
+++ b/pyflow/attributes.py
@@ -134,7 +134,10 @@ class Time(Attribute):
             ecflow_parent.add_time(self.value)
             return
 
-        time = Crontab(self.value)
+        try:
+            time = Crontab(self.value, time_only=True)
+        except AssertionError as exc:
+            raise ValueError(f"Invalid cron-like time format: {self.value}") from exc
         ecflow_parent.add_time(time.generate_time())
 
 

--- a/pyflow/cron.py
+++ b/pyflow/cron.py
@@ -110,11 +110,16 @@ def increment(a, b):
 
 
 class Crontab:
-    def __init__(self, cron):
+    def __init__(self, cron, time_only=False):
         minute, hour, day_of_month, month, day_of_week = parse_cron(cron)
         self._day_of_week = _expand(day_of_week)
         self._day_of_month = _expand(day_of_month)
         self._month = _expand(month)
+
+        if time_only:
+            assert self._day_of_week is None, "Day of week not supported"
+            assert self._day_of_month is None, "Day of month not supported"
+            assert self._month is None, "Month not supported"
 
         if minute is None and hour is None:
             ts = ecflow.TimeSeries(

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -37,6 +37,18 @@ time_values = [
     },
 ]
 
+time_non_supported = [
+    {
+        "time": "0 12 15 * *",
+    },
+    {
+        "time": "0 12 * 1 *",
+    },
+    {
+        "time": "0 12 * * SUN",
+    },
+]
+
 
 @pytest.mark.parametrize("time_value", time_values)
 def test_time(time_value):
@@ -46,6 +58,15 @@ def test_time(time_value):
 
     assert f"time {time_value['definition']}" in str(s.t)
 
+
+@pytest.mark.parametrize("time_value", time_non_supported)
+def test_non_supported_time(time_value):
+    with pyflow.Suite("s") as s:
+        with pyflow.Task("t"):
+                pyflow.Time(time_value["time"])
+
+    with pytest.raises(ValueError):
+        assert s.t
 
 cron_values = [
     {

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -63,10 +63,11 @@ def test_time(time_value):
 def test_non_supported_time(time_value):
     with pyflow.Suite("s") as s:
         with pyflow.Task("t"):
-                pyflow.Time(time_value["time"])
+            pyflow.Time(time_value["time"])
 
     with pytest.raises(ValueError):
         assert s.t
+
 
 cron_values = [
     {


### PR DESCRIPTION
Currently, when non-supported cron-like definition of `Time` are used, pyflow fails with a plain `AssertionError` which does not say the reason it should fail. Here we add some explicit messages.