### PR TITLE
Hotfix/3.4.2 Allow overriding signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist
 pyflow.slides.html
 course/scratch/*
 docs/_build
+pyflow/_version.py

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -15,8 +15,8 @@ dependencies:
   - pip:
     - ipykernel
     - nbsphinx
-    - sphinx-rtd-theme==0.5.2
-    - sphinx-copybutton==0.3.1
+    - sphinx-rtd-theme
+    - sphinx-copybutton
     - sphinx-tabs
     - git+https://github.com/ecmwf/pyflow.git
 

--- a/pyflow/host.py
+++ b/pyflow/host.py
@@ -77,7 +77,6 @@ DEFAULT_SIGNAL_LIST = [
     61,
     62,
     63,
-    64,
 ]
 
 

--- a/pyflow/host.py
+++ b/pyflow/host.py
@@ -31,6 +31,55 @@ ecflow_client --complete  # Notify ecFlow of a normal end
 exit 0
 """
 
+DEFAULT_SIGNAL_LIST = [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    10,
+    11,
+    13,
+    24,
+    31,
+    32,
+    33,
+    34,
+    35,
+    36,
+    37,
+    38,
+    39,
+    40,
+    41,
+    42,
+    43,
+    44,
+    45,
+    46,
+    47,
+    48,
+    49,
+    50,
+    51,
+    52,
+    53,
+    54,
+    55,
+    56,
+    57,
+    58,
+    59,
+    60,
+    61,
+    62,
+    63,
+    64,
+]
+
 
 SSH_COMMAND = "ssh -v -o StrictHostKeyChecking=no"
 
@@ -59,6 +108,7 @@ class Host:
         ecflow_path(str): The directory containing the `ecflow_client` executable.
         server_ecfvars(bool): If true, don't define ECF_JOB_CMD, ECF_KILL_CMD, ECF_STATUS_CMD and ECF_OUT variables
             and use defaults from server
+        trap_signals(list): The list of signals to trap. A default list is used if not set.
 
     Example::
 
@@ -84,6 +134,7 @@ class Host:
         user=getpass.getuser(),
         ecflow_path=None,
         server_ecfvars=False,
+        trap_signals=None,
     ):
         self.name = name
         self.hostname = hostname or name
@@ -118,6 +169,8 @@ class Host:
         self.ecflow_path = ecflow_path
 
         self.server_ecfvars = server_ecfvars
+
+        self.trap_signals = trap_signals or DEFAULT_SIGNAL_LIST
 
     def __str__(self):
         return "{}({})".format(self.__class__.__name__, self.hostname)
@@ -309,6 +362,7 @@ class Host:
                 script += f"    {line}\n"
         script += "}\n\n"
 
+        signal_list = " ".join(str(s) for s in self.trap_signals)
         script += textwrap.dedent(
             (
                 """
@@ -330,7 +384,7 @@ class Host:
 
             # Trap any signal that may cause the script to fail
             # Note: don't trap SIGTERM/SIGCONT for Slurm to properly reach shell children on cancel/timeout
-            export SIGNAL_LIST='1 2 3 4 5 6 7 8 10 11 13 24 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64'
+            export SIGNAL_LIST='%(signal_list)s'
 
             for signal in $SIGNAL_LIST; do
                 trap "ERROR $signal \\"Signal $(kill -l $signal) ($signal) received \\"" $signal
@@ -341,7 +395,7 @@ class Host:
             set -x
             """  # noqa: E501
             )
-            % {"ecf_path": ecflowpath}
+            % {"ecf_path": ecflowpath, "signal_list": signal_list}
         )
         return script
 
@@ -375,6 +429,7 @@ class NullHost(Host):
         ecflow_path(str): The directory containing the `ecflow_client` executable.
         server_ecfvars(bool): If true, don't define ECF_JOB_CMD, ECF_KILL_CMD, ECF_STATUS_CMD and ECF_OUT variables
             and use defaults from server
+        trap_signals(list): The list of signals to trap. A default list is used if not set.
 
     Example::
 
@@ -440,6 +495,7 @@ class LocalHost(Host):
         ecflow_path(str): The directory containing the `ecflow_client` executable.
         server_ecfvars(bool): If true, don't define ECF_JOB_CMD, ECF_KILL_CMD, ECF_STATUS_CMD and ECF_OUT variables
             and use defaults from server
+        trap_signals(list): The list of signals to trap. A default list is used if not set.
 
     Example::
 
@@ -564,6 +620,7 @@ class SSHHost(Host):
         ecflow_path(str): The directory containing the `ecflow_client` executable.
         server_ecfvars(bool): If true, don't define ECF_JOB_CMD, ECF_KILL_CMD, ECF_STATUS_CMD and ECF_OUT variables
             and use defaults from server
+        trap_signals(list): The list of signals to trap. A default list is used if not set.
 
     Example::
 
@@ -954,6 +1011,7 @@ class TroikaHost(Host):
         ecflow_path(str): The directory containing the `ecflow_client` executable.
         server_ecfvars(bool): If true, don't define ECF_JOB_CMD, ECF_KILL_CMD, ECF_STATUS_CMD and ECF_OUT variables
             and use defaults from server
+        trap_signals(list): The list of signals to trap. A default list is used if not set.
 
     Example::
 

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -344,11 +344,17 @@ def test_troika_host_options():
 def test_traps():
     sigs = [1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 13]
     with pyflow.Suite("s") as s1:
-        t1 = pyflow.Task("t1", host=pyflow.TroikaHost("a-host", user="me", trap_signals=sigs))
+        t1 = pyflow.Task(
+            "t1", host=pyflow.TroikaHost("a-host", user="me", trap_signals=sigs)
+        )
         t2 = pyflow.Task("t2", host=pyflow.TroikaHost("b-host", user="me"))
 
     signal_list1 = "export SIGNAL_LIST='1 2 3 4 5 6 7 8 10 11 13'\n"
-    signal_list2 = "export SIGNAL_LIST='" + " ".join(str(s) for s in pyflow.host.DEFAULT_SIGNAL_LIST) + "'\n"
+    signal_list2 = (
+        "export SIGNAL_LIST='"
+        + " ".join(str(s) for s in pyflow.host.DEFAULT_SIGNAL_LIST)
+        + "'\n"
+    )
 
     s1 = "\n".join(t1.generate_script()[0])
     s2 = "\n".join(t2.generate_script()[0])

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -1,6 +1,7 @@
 import pytest
 
 import pyflow
+import pyflow.host
 
 
 def test_host_task():
@@ -338,6 +339,22 @@ def test_troika_host_options():
         == "%TROIKA:/path/to/troika% -vv -c %TROIKA_CONFIG:/path/to/troika.cfg% kill -u test_user test_host %ECF_JOB%"  # noqa: E501
     )
     assert s.host.troika_version == (2, 1, 3)
+
+
+def test_traps():
+    sigs = [1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 13]
+    with pyflow.Suite("s") as s1:
+        t1 = pyflow.Task("t1", host=pyflow.TroikaHost("a-host", user="me", trap_signals=sigs))
+        t2 = pyflow.Task("t2", host=pyflow.TroikaHost("b-host", user="me"))
+
+    signal_list1 = "export SIGNAL_LIST='1 2 3 4 5 6 7 8 10 11 13'\n"
+    signal_list2 = "export SIGNAL_LIST='" + " ".join(str(s) for s in pyflow.host.DEFAULT_SIGNAL_LIST) + "'\n"
+
+    s1 = "\n".join(t1.generate_script()[0])
+    s2 = "\n".join(t2.generate_script()[0])
+
+    assert signal_list1 in s1
+    assert signal_list2 in s2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds a `trap_signals` argument to the `Host` class, which if set to a list of ints will override the default list of signals for which the task scripts will trap.