### PR TITLE
Fix broken documentation

### DIFF
--- a/.github/workflows/readthedocs-pr.yml
+++ b/.github/workflows/readthedocs-pr.yml
@@ -2,7 +2,7 @@
 # This does NOT trigger a build of the documentation, this is handled through webhooks.
 name: Read the Docs PR Preview
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize

--- a/.github/workflows/readthedocs-pr.yml
+++ b/.github/workflows/readthedocs-pr.yml
@@ -21,4 +21,4 @@ jobs:
     steps:
       - uses: readthedocs/actions/preview@v1
         with:
-          project-slug: "pyflow"
+          project-slug: "pyflow-workflow-generator"

--- a/.github/workflows/readthedocs-pr.yml
+++ b/.github/workflows/readthedocs-pr.yml
@@ -1,0 +1,24 @@
+# This workflow adds a link to the experimental documentation build to the PR.
+# This does NOT trigger a build of the documentation, this is handled through webhooks.
+name: Read the Docs PR Preview
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    # Execute this action only on PRs that touch
+    # documentation files.
+    paths:
+      - "docs/**"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "pyflow"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,9 +133,7 @@ html_static_path = ["_static"]
 
 # These paths are either relative to html_static_path
 # or fully qualified paths (eg. https://...)
-html_css_files = [
-    "style.css"
-]
+html_css_files = ["style.css"]
 
 html_js_files = []
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,7 +131,13 @@ html_theme = "sphinx_rtd_theme"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
-html_context = {"css_files": ["_static/style.css"]}
+# These paths are either relative to html_static_path
+# or fully qualified paths (eg. https://...)
+html_css_files = [
+    "style.css"
+]
+
+html_js_files = []
 
 # Remove links to the reST sources from the page headers.
 html_show_sourcelink = False


### PR DESCRIPTION
This fix the rtd theme for the documentation after updating sphinx extension versions

<!-- readthedocs-preview pyflow-workflow-generator start -->
----
📚 Documentation preview 📚: https://pyflow-workflow-generator--78.org.readthedocs.build/en/78/

<!-- readthedocs-preview pyflow-workflow-generator end -->