### PR TITLE
Feature/improved warnings

### DIFF
--- a/pyflow/__init__.py
+++ b/pyflow/__init__.py
@@ -3,7 +3,10 @@
 from __future__ import absolute_import
 
 import warnings
-warnings.formatwarning = lambda mess, category, filename, lineno, *args: f"\033[93m[{category.__name__}] {filename}:{lineno}\n{mess}\n\033[0m"
+
+warnings.formatwarning = (
+    lambda mess, category, filename, lineno, *args: f"\033[93m[{category.__name__}] {filename}:{lineno}\n{mess}\n\033[0m"
+)
 warnings.filterwarnings("default", category=DeprecationWarning)
 warn = warnings.warn
 

--- a/pyflow/__init__.py
+++ b/pyflow/__init__.py
@@ -2,6 +2,10 @@
 
 from __future__ import absolute_import
 
+import warnings
+warnings.formatwarning = lambda mess, category, filename, lineno, *args: f"\033[93m[{category.__name__}] {filename}:{lineno}\n{mess}\n\033[0m"
+warn = warnings.warn
+
 from .attributes import (
     Aviso,
     Complete,

--- a/pyflow/__init__.py
+++ b/pyflow/__init__.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 
 import warnings
 warnings.formatwarning = lambda mess, category, filename, lineno, *args: f"\033[93m[{category.__name__}] {filename}:{lineno}\n{mess}\n\033[0m"
+warnings.filterwarnings("default", category=DeprecationWarning)
 warn = warnings.warn
 
 from .attributes import (

--- a/pyflow/anchor.py
+++ b/pyflow/anchor.py
@@ -2,6 +2,7 @@ import os
 
 from . import warn
 
+
 class AnchorMixin:
     """
     A mixin to define Anchor behaviour --> part of Suite and of Family

--- a/pyflow/anchor.py
+++ b/pyflow/anchor.py
@@ -1,5 +1,6 @@
 import os
 
+from . import warn
 
 class AnchorMixin:
     """
@@ -12,8 +13,10 @@ class AnchorMixin:
         variables.update(kwargs)
 
         if "out" in kwargs:
-            print(
-                "WARNING! out option is deprecated for nodes, use the log_directory option in the host instead"
+            warn(
+                "'out' option is deprecated for nodes, use the log_directory option in the host instead",
+                DeprecationWarning,
+                stacklevel=2,
             )
 
         for control_variable in ("files", "include", "home", "out", "extn"):

--- a/pyflow/deployment.py
+++ b/pyflow/deployment.py
@@ -5,6 +5,7 @@ import hashlib
 import os
 import shutil
 
+from pyflow import warn
 from pyflow.html import FileListHTMLWrapper
 
 
@@ -232,7 +233,7 @@ class FileSystem(Deployment):
             try:
                 os.makedirs(path)
             except Exception:
-                print("WARNING: Couldn't create directory: {}".format(path))
+                warn("Couldn't create directory: {}".format(path), stacklevel=0)
 
     def check(self, target):
         """

--- a/pyflow/host.py
+++ b/pyflow/host.py
@@ -8,6 +8,8 @@ import pwd
 import shutil
 import textwrap
 
+from . import warn
+from .inspect import get_value_at_caller
 from .attributes import Label, Limit
 from .base import STACK
 from .nodes import DuplicateNodeError, Family, ecflow_name
@@ -307,9 +309,13 @@ class Host:
 
     def script_submit_arguments(self, submit_arguments):
         if len(submit_arguments) > 0:
-            print(
-                f"Host {self.__class__.__name__} does not support scheduler submission arguments. \
-                    Submission arguments will be ignored in the script generation",
+            node = get_value_at_caller("self", 2)
+            name = getattr(node, "name", node)
+            warn(
+                f"Host {self.__class__.__name__} does not support scheduler submission arguments, which "
+                f"will be ignored in the script generation for task {name}. ",
+                UserWarning,
+                stacklevel=0,
             )
         return []
 
@@ -1169,8 +1175,11 @@ class TroikaHost(Host):
                     args.append(pragma)
             else:
                 if arg in deprecated:
-                    print(
-                        f"WARNING! '{arg}' is deprecated, use '{deprecated[arg]}' instead"
+                    node = get_value_at_caller("self", stacklevel=2)
+                    name = getattr(node, "fullname", getattr(node, "name", node))
+                    warn(
+                        f"{name}: {arg}' is deprecated in TroikaHost, use '{deprecated[arg]}' instead",
+                        stacklevel=0,
                     )
                     arg = deprecated[arg]
                 if arg is not None:

--- a/pyflow/host.py
+++ b/pyflow/host.py
@@ -310,10 +310,10 @@ class Host:
     def script_submit_arguments(self, submit_arguments):
         if len(submit_arguments) > 0:
             node = get_value_at_caller("self", 2)
-            name = getattr(node, "name", node)
+            name = getattr(node, "fullname", getattr(node, "name", node))
             warn(
-                f"Host {self.__class__.__name__} does not support scheduler submission arguments, which "
-                f"will be ignored in the script generation for task {name}. ",
+                f"{name}: Host {self.__class__.__name__} does not support scheduler submission arguments, which "
+                f"will be ignored in the script generation. ",
                 UserWarning,
                 stacklevel=0,
             )
@@ -1179,6 +1179,7 @@ class TroikaHost(Host):
                     name = getattr(node, "fullname", getattr(node, "name", node))
                     warn(
                         f"{name}: {arg}' is deprecated in TroikaHost, use '{deprecated[arg]}' instead",
+                        DeprecationWarning,
                         stacklevel=0,
                     )
                     arg = deprecated[arg]

--- a/pyflow/host.py
+++ b/pyflow/host.py
@@ -9,9 +9,9 @@ import shutil
 import textwrap
 
 from . import warn
-from .inspect import get_value_at_caller
 from .attributes import Label, Limit
 from .base import STACK
+from .inspect import get_value_at_caller
 from .nodes import DuplicateNodeError, Family, ecflow_name
 
 SET_ECF_VARIABLES = """

--- a/pyflow/inspect.py
+++ b/pyflow/inspect.py
@@ -1,9 +1,10 @@
 import inspect
 
+
 def get_value_at_caller(target="self", stacklevel=2):
     """
     returns the value of a variable in the caller's frame. Useful for getting
-    caller objects or variables at caller level, e.g, a Task name when defining its 
+    caller objects or variables at caller level, e.g, a Task name when defining its
     submit arguments on its Host.
     :param target: The name of the variable to retrieve from the caller's frame.
                    Defaults to "self", which is common in class methods.
@@ -18,5 +19,5 @@ def get_value_at_caller(target="self", stacklevel=2):
         frame = frame.f_back
     # Get local variables in the caller's frame
     locals_ = frame.f_locals
-    
+
     return locals_.get(target, None)

--- a/pyflow/inspect.py
+++ b/pyflow/inspect.py
@@ -1,0 +1,22 @@
+import inspect
+
+def get_value_at_caller(target="self", stacklevel=2):
+    """
+    returns the value of a variable in the caller's frame. Useful for getting
+    caller objects or variables at caller level, e.g, a Task name when defining its 
+    submit arguments on its Host.
+    :param target: The name of the variable to retrieve from the caller's frame.
+                   Defaults to "self", which is common in class methods.
+    :param stacklevel: The number of frames to go back in the call stack.
+                      Defaults to 2, which means it will look at the frame of immediate caller.
+    """
+
+    frame = inspect.stack()[1].frame
+    for _ in range(stacklevel - 1):
+        if frame is None:
+            raise ValueError(f"No caller frame found with stacklevel {stacklevel}.")
+        frame = frame.f_back
+    # Get local variables in the caller's frame
+    locals_ = frame.f_locals
+    
+    return locals_.get(target, None)

--- a/pyflow/nodes.py
+++ b/pyflow/nodes.py
@@ -1163,7 +1163,7 @@ class Suite(AnchorMixin, Node):
                 target.deploy_task(t.deploy_path, script, includes)
             except Exception as e:
                 print(f"\nERROR when deploying task: {t.fullname}\n")
-                raise(e)
+                raise (e)
         for f in node.all_families:
             manual = self.generate_stub(f.manual)
             if manual:

--- a/pyflow/nodes.py
+++ b/pyflow/nodes.py
@@ -1161,9 +1161,9 @@ class Suite(AnchorMixin, Node):
             script, includes = t.generate_script()
             try:
                 target.deploy_task(t.deploy_path, script, includes)
-            except RuntimeError:
+            except Exception as e:
                 print(f"\nERROR when deploying task: {t.fullname}\n")
-                raise
+                raise(e)
         for f in node.all_families:
             manual = self.generate_stub(f.manual)
             if manual:

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -315,7 +315,6 @@ def test_troika_host():
 
 
 def test_host_submit_args():
-
     submit_args = {
         "troika": {
             "tasks": 2,  # deprecated option, will be translated to total_tasks


### PR DESCRIPTION
### Description

Improved warnings formmating and messages for users with hints on where to change things.

Note: DeprecationWarnings had to be set to `default` as they are ignored by default
Note: warning formatting will make text appear in yellow on most terminals but this has not been extensively tested.

#### New deprecation warning on TroikaHost submit arguments

```shell
[DeprecationWarning] /Users/mojp/github/pyflow/pyflow/host.py:1180
/my_suite/init/deploy_data/git_sample: tmpdir' is deprecated in TroikaHost, use 'tmpdir_size' instead
```

#### When defining submit arguments to LocalHost

```shell
[DeprecationWarning] /Users/mojp/github/pyflow/pyflow/host.py:1180
/my_suite/init/deploy_data/mars_sample: tmpdir' is deprecated in TroikaHost, use 'tmpdir_size' instead
```

#### When using `out` option for a node
```shell
[DeprecationWarning] /Users/mojp/github/pyflow/pyflow/nodes.py:1071
'out' option is deprecated for nodes, use the log_directory option in the host instead
```

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 