### PR TITLE
allow (ignore) None as a empty definition

### DIFF
--- a/pyflow/adder.py
+++ b/pyflow/adder.py
@@ -55,7 +55,10 @@ class NodeAdder:
         self.add(other)
 
     def _create(self, other):
-        assert other is not None
+
+        result = []
+        if other is None:
+            return result
 
         if isinstance(other, dict):
             other = [it for it in other.items()]
@@ -63,7 +66,6 @@ class NodeAdder:
         if not isinstance(other, list):
             other = [other]
 
-        result = []
         for o in other:
             if isinstance(o, tuple):
                 if len(o) == 2 and isinstance(o[1], dict):


### PR DESCRIPTION
### Description
If you have an empty definition passed through a node `kwargs` , like `pf.Task(name="t1", cron=None)`, pyflow raises `AssertionError` for no apparent reason. Here it will just ignore the cron definition and move on. 

This allows more flexibility when changing the node properties depending on configuration more explicitly. 

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 