### PR TITLE
Add mirror attribute to `Task`

### DIFF
--- a/pyflow/attributes.py
+++ b/pyflow/attributes.py
@@ -1421,10 +1421,17 @@ class Mirror(Attribute):
         force: bool = False,
     ):
         super().__init__(name)
-        if int(polling) < 60 and not force:
-            raise ValueError(
-                "Polling time should be at least 60 seconds. Use force=True to override."
-            )
+        if not force:
+            try:
+                polling = int(polling)
+            except ValueError:
+                pass  # polling is not an integer, so we cannot validate it here
+
+            if isinstance(polling, int) and polling < 60:
+                raise ValueError(
+                    "Mirror polling interval must be at least 60 seconds. Use force=True to override."
+                )
+
         self.remote_path = str(remote_path)
         self.remote_host = str(remote_host)
         self.remote_port = str(remote_port)

--- a/pyflow/attributes.py
+++ b/pyflow/attributes.py
@@ -1394,6 +1394,7 @@ class Mirror(Attribute):
         polling(str, int): The time interval used to poll the remote ecFlow server.
         ssl(bool): The flag indicating if SSL communication is enabled.
         auth(str): The path to the ecFlow authentication credentials file.
+        force(bool): The flag indicating whether to override lower limit on polling time
 
 
     Example::
@@ -1402,14 +1403,28 @@ class Mirror(Attribute):
                      "/suite/family/task",
                      "remote-ecflow-server",
                      "3141",
-                     60,
+                     300,
                      False
                      "/path/to/auth.json")
 
     """
 
-    def __init__(self, name, remote_path, remote_host, remote_port, polling, ssl, auth):
+    def __init__(
+        self,
+        name: str,
+        remote_path: str,
+        remote_host: str,
+        remote_port: str,
+        auth: str = "",
+        polling: int = 300,
+        ssl: bool = False,
+        force: bool = False,
+    ):
         super().__init__(name)
+        if int(polling) < 60 and not force:
+            raise ValueError(
+                "Polling time should be at least 60 seconds. Use force=True to override."
+            )
         self.remote_path = str(remote_path)
         self.remote_host = str(remote_host)
         self.remote_port = str(remote_port)

--- a/pyflow/attributes.py
+++ b/pyflow/attributes.py
@@ -1429,7 +1429,7 @@ class Mirror(Attribute):
 
             if isinstance(polling, int) and polling < 60:
                 raise ValueError(
-                    "Mirror polling interval must be at least 60 seconds. Use force=True to override."
+                    "Mirror polling interval must be at least 60s to avoid overloading the remote server. Use force=True to override."
                 )
 
         self.remote_path = str(remote_path)

--- a/pyflow/attributes.py
+++ b/pyflow/attributes.py
@@ -1429,7 +1429,8 @@ class Mirror(Attribute):
 
             if isinstance(polling, int) and polling < 60:
                 raise ValueError(
-                    "Mirror polling interval must be at least 60s to avoid overloading the remote server. Use force=True to override."
+                    "Mirror polling interval must be at least 60s to avoid overloading \
+                    the remote server. Use force=True to override."
                 )
 
         self.remote_path = str(remote_path)

--- a/pyflow/expressions.py
+++ b/pyflow/expressions.py
@@ -300,7 +300,7 @@ class Or(BinOp):
         super().__init__("or", left, right, 0)
 
     def _simplify(self):
-        (l, r) = (self._left.evaluate(), self._right.evaluate())
+        l, r = (self._left.evaluate(), self._right.evaluate())
 
         if l is not UNDEFINED and r is not UNDEFINED:
             return self._left.value or self._right.value
@@ -327,7 +327,7 @@ class And(BinOp):
         super().__init__("and", left, right, 0)
 
     def _simplify(self):
-        (l, r) = (self._left.evaluate(), self._right.evaluate())
+        l, r = (self._left.evaluate(), self._right.evaluate())
 
         if l is not UNDEFINED and r is not UNDEFINED:
             return self._left.value and self._right.value

--- a/pyflow/host.py
+++ b/pyflow/host.py
@@ -378,9 +378,7 @@ class Host:
             *str*: The preamble initialisation script.
         """
 
-        script = (
-            textwrap.dedent(
-                """
+        script = textwrap.dedent("""
         # ----------------------------- ECFLOW INIT ----------------------------
 
         export PATH=%(ecf_path)s:$PATH
@@ -389,10 +387,7 @@ class Host:
 
         # Tell ecFlow we have started
         ecflow_client --init=$$
-        """
-            )
-            % {"ecf_path": ecflowpath}
-        )
+        """) % {"ecf_path": ecflowpath}
 
         return script
 
@@ -409,22 +404,18 @@ class Host:
         """
         script = ""
 
-        script += textwrap.dedent(
-            """
+        script += textwrap.dedent("""
             # custom exit/cleanup code
             exit_hook () {
                 echo "cleaning up ...."
-            """
-        )
+            """)
         if exit_hook:
             for line in exit_hook:
                 script += f"    {line}\n"
         script += "}\n\n"
 
         signal_list = " ".join(str(s) for s in self.trap_signals)
-        script += textwrap.dedent(
-            (
-                """
+        script += textwrap.dedent(("""
             # ----------------------------- TRAPS FOR SUBMITTED JOBS ----------------------------
             set +x
             # Define a error handler
@@ -452,10 +443,7 @@ class Host:
             # Trap any calls to exit and errors caught by the -e flag
             trap ERROR 0
             set -x
-            """  # noqa: E501
-            )
-            % {"ecf_path": ecflowpath, "signal_list": signal_list}
-        )
+            """) % {"ecf_path": ecflowpath, "signal_list": signal_list})  # noqa: E501
         return script
 
     def job_preamble(self, exit_hook=None):

--- a/pyflow/nodes.py
+++ b/pyflow/nodes.py
@@ -25,6 +25,7 @@ from .attributes import (
     Limit,
     Manual,
     Meter,
+    Mirror,
     Time,
     Today,
     Trigger,
@@ -142,6 +143,7 @@ class Node(Base):
             limits(Limit_): An attribute for a simple load management by limiting the number of tasks submitted by a
                 specific **ecFlow** server.
             meters(Meter_): An attribute for a range of integer values that can be set from a script.
+            mirror(Mirror_): An attribute for a mirroring a node on another ecflow server.
             tasks(Task_): An attribute for adding a child task on the node.
             time(Time_): An attribute for setting a time dependency of the node.
             today(Today_): An attribute for setting a cron dependency of the node for the current day.
@@ -857,6 +859,7 @@ class Family(Node):
             limits(Limit_): An attribute for a simple load management by limiting the number of tasks submitted by a
                 specific **ecFlow** server.
             meters(Meter_): An attribute for a range of integer values that can be set from a script.
+            mirror(Mirror_): An attribute for a mirroring a node on another ecflow server.
             tasks(Task_): An attribute for adding a child task on the node.
             time(Time_): An attribute for setting a time dependency of the node.
             today(Today_): An attribute for setting a cron dependency of the node for the current day.
@@ -985,6 +988,7 @@ class AnchorFamily(AnchorMixin, Family):
             limits(Limit_): An attribute for a simple load management by limiting the number of tasks submitted by a
                 specific **ecFlow** server.
             meters(Meter_): An attribute for a range of integer values that can be set from a script.
+            mirror(Mirror_): An attribute for a mirroring a node on another ecflow server.
             tasks(Task_): An attribute for adding a child task on the node.
             time(Time_): An attribute for setting a time dependency of the node.
             today(Today_): An attribute for setting a cron dependency of the node for the current day.
@@ -1060,6 +1064,7 @@ class Suite(AnchorMixin, Node):
             limits(Limit_): An attribute for a simple load management by limiting the number of tasks submitted by a
                 specific **ecFlow** server.
             meters(Meter_): An attribute for a range of integer values that can be set from a script.
+            mirror(Mirror_): An attribute for a mirroring a node on another ecflow server.
             tasks(Task_): An attribute for adding a child task on the node.
             time(Time_): An attribute for setting a time dependency of the node.
             today(Today_): An attribute for setting a cron dependency of the node for the current day.
@@ -1270,6 +1275,7 @@ class Task(Node):
             limits(Limit_): An attribute for a simple load management by limiting the number of tasks submitted by a
                 specific **ecFlow** server.
             meters(Meter_): An attribute for a range of integer values that can be set from a script.
+            mirror(Mirror_): An attribute for a mirroring a node on another ecflow server.
             tasks(Task_): An attribute for adding a child task on the node.
             time(Time_): An attribute for setting a time dependency of the node.
             today(Today_): An attribute for setting a cron dependency of the node for the current day.
@@ -1553,6 +1559,7 @@ ACCESSORS = [
     ("generated_variables", GeneratedVariable),
     ("zombies", Zombies),
     ("events", Event),
+    ("mirror", Mirror),
 ]
 
 

--- a/pyflow/nodes.py
+++ b/pyflow/nodes.py
@@ -859,7 +859,6 @@ class Family(Node):
             limits(Limit_): An attribute for a simple load management by limiting the number of tasks submitted by a
                 specific **ecFlow** server.
             meters(Meter_): An attribute for a range of integer values that can be set from a script.
-            mirror(Mirror_): An attribute for a mirroring a node on another ecflow server.
             tasks(Task_): An attribute for adding a child task on the node.
             time(Time_): An attribute for setting a time dependency of the node.
             today(Today_): An attribute for setting a cron dependency of the node for the current day.
@@ -988,7 +987,6 @@ class AnchorFamily(AnchorMixin, Family):
             limits(Limit_): An attribute for a simple load management by limiting the number of tasks submitted by a
                 specific **ecFlow** server.
             meters(Meter_): An attribute for a range of integer values that can be set from a script.
-            mirror(Mirror_): An attribute for a mirroring a node on another ecflow server.
             tasks(Task_): An attribute for adding a child task on the node.
             time(Time_): An attribute for setting a time dependency of the node.
             today(Today_): An attribute for setting a cron dependency of the node for the current day.
@@ -1064,7 +1062,6 @@ class Suite(AnchorMixin, Node):
             limits(Limit_): An attribute for a simple load management by limiting the number of tasks submitted by a
                 specific **ecFlow** server.
             meters(Meter_): An attribute for a range of integer values that can be set from a script.
-            mirror(Mirror_): An attribute for a mirroring a node on another ecflow server.
             tasks(Task_): An attribute for adding a child task on the node.
             time(Time_): An attribute for setting a time dependency of the node.
             today(Today_): An attribute for setting a cron dependency of the node for the current day.

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -740,7 +740,7 @@ class TestMirror:
                 with pyflow.Task("t") as t:
                     assert "t" == t.name
 
-                    attr = pyflow.Mirror(
+                    pyflow.Mirror(
                         name="MIRROR_ATTRIBUTE",
                         remote_path="/s/f/t",
                         remote_host="remote-ecflow-server",

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -681,46 +681,36 @@ class TestMirror:
     """A set of tests for Mirror attributes."""
 
     def test_create_mirror_from_strings(self):
-        name = "MIRROR_ATTRIBUTE"
-        remote_path = "/s/f/t"
-        remote_host = "remote-ecflow-server"
-        remote_port = "3141"
-        polling = "%ECFLOW_MIRROR_POLLING%"
-        ssl = True
-        auth = "/path/to/auth.json"
+        setup = {
+            "name": "MIRROR_ATTRIBUTE",
+            "remote_path": "/s/f/t",
+            "remote_host": "remote-ecflow-server",
+            "remote_port": "3141",
+            "polling": "%ECFLOW_MIRROR_REMOTE_POLLING%",
+            "ssl": True,
+            "auth": "/path/to/auth.json",
+        }
 
-        attr = pyflow.Mirror(
-            name, remote_path, remote_host, remote_port, polling, ssl, auth
-        )
+        attr = pyflow.Mirror(**setup)
 
-        assert attr.name == name
-        assert attr.remote_path == remote_path
-        assert attr.remote_host == remote_host
-        assert attr.remote_port == remote_port
-        assert attr.polling == polling
-        assert attr.ssl == ssl
-        assert attr.auth == auth
+        for name, value in setup.items():
+            assert getattr(attr, name) == value
 
     def test_create_mirror_from_objects(self):
-        name = "MIRROR_ATTRIBUTE"
-        remote_path = "/s/f/t"
-        remote_host = "remote-ecflow-server"
-        remote_port = 3141
-        polling = 60
-        ssl = True
-        auth = "/path/to/auth.json"
+        setup = {
+            "name": "MIRROR_ATTRIBUTE",
+            "remote_path": "/s/f/t",
+            "remote_host": "remote-ecflow-server",
+            "remote_port": "3141",
+            "polling": 600,
+            "ssl": True,
+            "auth": "/path/to/auth.json",
+        }
 
-        attr = pyflow.Mirror(
-            name, remote_path, remote_host, remote_port, polling, ssl, auth
-        )
+        attr = pyflow.Mirror(**setup)
 
-        assert attr.name == name
-        assert attr.remote_path == remote_path
-        assert attr.remote_host == remote_host
-        assert attr.remote_port == str(remote_port)
-        assert attr.polling == str(polling)
-        assert attr.ssl == ssl
-        assert attr.auth == auth
+        for name, value in setup.items():
+            assert type(value)(getattr(attr, name)) == value
 
     def test_create_mirror_on_task(self):
         with pyflow.Suite("s") as s:
@@ -730,16 +720,14 @@ class TestMirror:
                 with pyflow.Task("t") as t:
                     assert "t" == t.name
 
-                    name = "MIRROR_ATTRIBUTE"
-                    remote_path = "/s/f/t"
-                    remote_host = "remote-ecflow-server"
-                    remote_port = 3141
-                    polling = 60
-                    ssl = True
-                    auth = "/path/to/auth.json"
-
                     pyflow.Mirror(
-                        name, remote_path, remote_host, remote_port, polling, ssl, auth
+                        name="MIRROR_ATTRIBUTE",
+                        remote_path="/s/f/t",
+                        remote_host="remote-ecflow-server",
+                        remote_port="3141",
+                        polling=600,
+                        ssl=True,
+                        auth="/path/to/auth.json",
                     )
 
         s.check_definition()
@@ -752,16 +740,14 @@ class TestMirror:
                 with pyflow.Task("t") as t:
                     assert "t" == t.name
 
-                    name = "MIRROR_ATTRIBUTE"
-                    remote_path = "/s/f/t"
-                    remote_host = "remote-ecflow-server"
-                    remote_port = 3141
-                    polling = 60
-                    ssl = True
-                    auth = "/path/to/auth.json"
-
-                    pyflow.Mirror(
-                        name, remote_path, remote_host, remote_port, polling, ssl, auth
+                    attr = pyflow.Mirror(
+                        name="MIRROR_ATTRIBUTE",
+                        remote_path="/s/f/t",
+                        remote_host="remote-ecflow-server",
+                        remote_port="3141",
+                        polling=600,
+                        ssl=True,
+                        auth="/path/to/auth.json",
                     )
 
         defs = s.ecflow_definition()

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -44,20 +44,14 @@ def test_script_lists():
     t2.script += "echo 'bit4'"
     t2.script += ["echo 'bit5'", "echo 'bit6'"]
 
-    checkscript = os.linesep.join(
-        line
-        for line in textwrap.dedent(
-            """
+    checkscript = os.linesep.join(line for line in textwrap.dedent("""
         echo 'bit1'
         echo 'bit2'
         echo 'bit3'
         echo 'bit4'
         echo 'bit5'
         echo 'bit6'
-    """
-        ).splitlines()
-        if line
-    )
+    """).splitlines() if line)
 
     assert t1.script.value == checkscript
     assert t2.script.value == checkscript
@@ -156,10 +150,7 @@ def test_python_script():
 
             t = pyflow.Task("t", script=[s1, s2, s3, s4, s5])
 
-    checkscript = os.linesep.join(
-        line
-        for line in textwrap.dedent(
-            """
+    checkscript = os.linesep.join(line for line in textwrap.dedent("""
         echo 'bit1'
         python3 -u - <<EOS
         print "I am in Python (default)"
@@ -171,10 +162,7 @@ def test_python_script():
         print("I am a python 3 script")
         EOS
         echo 'bit3'
-    """
-        ).splitlines()
-        if line
-    )
+    """).splitlines() if line)
 
     assert checkscript == t.script.value
 
@@ -183,8 +171,7 @@ def test_python_script_cmd_args():
     with pyflow.Suite("s"):
         with pyflow.Family("f"):
             s1 = pyflow.PythonScript(
-                textwrap.dedent(
-                    """
+                textwrap.dedent("""
                 import argparse
 
                 if __name__ == "__main__":
@@ -196,14 +183,12 @@ def test_python_script_cmd_args():
 
                     print(args.key_1)
                     print(args.key_2)
-                """
-                ),
+                """),
                 cmd_args={"key-1": "value-1", "key-2": "value-2"},
                 python=3,
             )
             s2 = pyflow.PythonScript(
-                textwrap.dedent(
-                    """
+                textwrap.dedent("""
                 import argparse
 
                 if __name__ == "__main__":
@@ -215,8 +200,7 @@ def test_python_script_cmd_args():
 
                     print(args.key_1)
                     print(args.key_2)
-                """
-                ),
+                """),
                 cmd_args={"key-1": "value-1", "key-2": "value-2"},
                 python=2,
             )
@@ -229,8 +213,7 @@ def test_python_script_cmd_args():
             t2 = pyflow.Task("t2", script=[s2])
             t3 = pyflow.Task("t3", script=[s3])
 
-    checkscript_python3 = textwrap.dedent(
-        """
+    checkscript_python3 = textwrap.dedent("""
         python3 -u - --key-1=value-1 --key-2=value-2 <<EOS
         import argparse
 
@@ -244,11 +227,9 @@ def test_python_script_cmd_args():
             print(args.key_1)
             print(args.key_2)
         EOS
-        """
-    )
+        """)
 
-    checkscript_python2 = textwrap.dedent(
-        """
+    checkscript_python2 = textwrap.dedent("""
         python2 -u - --key-1=value-1 --key-2=value-2 <<EOS
         import argparse
 
@@ -262,15 +243,12 @@ def test_python_script_cmd_args():
             print(args.key_1)
             print(args.key_2)
         EOS
-        """
-    )
+        """)
 
-    checkscript_empty = textwrap.dedent(
-        """
+    checkscript_empty = textwrap.dedent("""
         python3 -u - <<EOS
         EOS
-        """
-    )
+        """)
 
     assert checkscript_python3.strip() == t1.script.value.strip()
     assert checkscript_python2.strip() == t2.script.value.strip()
@@ -320,16 +298,14 @@ def test_template_script():
 
     task.script = pyflow.TemplateScript(
         pyflow.PythonScript(
-            textwrap.dedent(
-                """
+            textwrap.dedent("""
                 import ecflow
                 print("Static text {{ TEXT_STRING }}")
                 print("Contents of variable ({{ TEMPLATE_VARIABLE.fullname }}): {{ TEMPLATE_VARIABLE }}")
                 print("Contents of another ({{ ANOTHER_VARIABLE.fullname }}): {{ ANOTHER_VARIABLE }}")
                 ci = ecflow.Client()
                 ci.alter("{{ LABEL.parent.fullname }}", "change", "label", "{{ LABEL.name }}", "value")
-            """
-            ),
+            """),
             python=3,
         ),
         TEXT_STRING="some text",
@@ -338,8 +314,7 @@ def test_template_script():
         LABEL=lab,
     )
 
-    checkscript = textwrap.dedent(
-        """
+    checkscript = textwrap.dedent("""
         python3 -u - <<EOS
         import ecflow
         print("Static text some text")
@@ -348,8 +323,7 @@ def test_template_script():
         ci = ecflow.Client()
         ci.alter("/s/f", "change", "label", "A_LABEL", "value")
         EOS
-    """
-    )[1:-1]
+    """)[1:-1]
 
     assert task.script.value == checkscript
 
@@ -358,14 +332,12 @@ def test_variable_detection_script():
     s_vars = {"S_FOO": "hello", "S_BAR": 1, "S_FOO_S_BAR": "3"}
     with pyflow.Suite("s", variables=s_vars):
         t_vars = {"T_FOO": "salut", "T_BAR": 2, "T_FOO_T_BAR": "4"}
-        t_script = pyflow.Script(
-            """
+        t_script = pyflow.Script("""
                 echo S_BAR is $S_BAR
                 echo S_FOO_S_BAR is ${S_FOO_S_BAR}
                 echo T_FOO is ${T_FOO:-2}
                 echo T_BAR is ${T_BAR=10}
-            """
-        )
+            """)
         t = pyflow.Task("t", variables=t_vars, script=t_script)
 
     full_script = t.generate_script()

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -11,14 +11,12 @@ def test_generate_variables():
             t = pyflow.Task(
                 "t1",
                 VARIABLE3="variable3",
-                script=textwrap.dedent(
-                    """
+                script=textwrap.dedent("""
                 echo "$VARIABLE1"
                 echo "$VARIABLE2"
                 echo "$VARIABLE3"
                 echo "$VARIABLE4
-            """
-                ),
+            """),
             )
 
     script, includes = t.generate_script()


### PR DESCRIPTION
### Description
Add defaults to `attributes.Mirror`, enforcing a default lower limit on polling time and also add attribute to `Task`.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 