### PR TITLE
Add multiplication to expressions

### DIFF
--- a/pyflow/attributes.py
+++ b/pyflow/attributes.py
@@ -21,6 +21,7 @@ from .expressions import (
     Mod,
     Ne,
     Sub,
+    Mul,
     expression_from_json,
     make_expression,
 )
@@ -427,6 +428,9 @@ class RepeatString(Repeat):
 
     def __sub__(self, other):
         return Sub(self, other)
+    
+    def __mul__(self, other):
+        return Mul(self, other)
 
 
 class RepeatEnumerated(Repeat):
@@ -459,6 +463,9 @@ class RepeatEnumerated(Repeat):
 
     def __sub__(self, other):
         return Sub(self, other)
+    
+    def __mul__(self, other):
+        return Mul(self, other)
 
 
 class RepeatDateList(Repeat):
@@ -536,6 +543,9 @@ class RepeatInteger(Repeat):
 
     def __sub__(self, other):
         return Sub(self, other)
+
+    def __mul__(self, other):
+        return Mul(self, other)
 
 
 class RepeatDate(Repeat):

--- a/pyflow/attributes.py
+++ b/pyflow/attributes.py
@@ -19,9 +19,9 @@ from .expressions import (
     Le,
     Lt,
     Mod,
+    Mul,
     Ne,
     Sub,
-    Mul,
     expression_from_json,
     make_expression,
 )
@@ -428,7 +428,7 @@ class RepeatString(Repeat):
 
     def __sub__(self, other):
         return Sub(self, other)
-    
+
     def __mul__(self, other):
         return Mul(self, other)
 
@@ -463,7 +463,7 @@ class RepeatEnumerated(Repeat):
 
     def __sub__(self, other):
         return Sub(self, other)
-    
+
     def __mul__(self, other):
         return Mul(self, other)
 

--- a/pyflow/expressions.py
+++ b/pyflow/expressions.py
@@ -265,6 +265,17 @@ class BinOp(Expression):
         return self._simplify()
 
 
+class BinMatOp(BinOp):
+    def __mul__(self, other):
+        return Mul(self, other)
+
+    def __add__(self, other):
+        return Add(self, other)
+
+    def __sub__(self, other):
+        return Sub(self, other)
+
+
 class Ne(BinOp):
     def __init__(self, left, right):
         super().__init__("ne", left, right, 1)
@@ -349,24 +360,29 @@ class And(BinOp):
         return self
 
 
-class Sub(BinOp):
+class Sub(BinMatOp):
     def __init__(self, left, right):
         super().__init__("-", left, right, 2)
 
 
-class Add(BinOp):
+class Add(BinMatOp):
     def __init__(self, left, right):
         super().__init__("+", left, right, 2)
 
 
-class Mod(BinOp):
+class Mod(BinMatOp):
     def __init__(self, left, right):
         super().__init__("%", left, right, 3)
 
 
-class Div(BinOp):
+class Div(BinMatOp):
     def __init__(self, left, right):
         super().__init__("/", left, right, 3)
+
+
+class Mul(BinMatOp):
+    def __init__(self, left, right):
+        super().__init__("*", left, right, 3)
 
 
 class Atom(Expression):

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -296,13 +296,15 @@ class TestRepeats:
 
                 t1 = pyflow.Task("t1")
                 t1.triggers = (f1.STRING_REPEAT == "7") & (f1.STRING_REPEAT == 3)
-                t1.triggers |= (f1.STRING_REPEAT + 2 == 7) & (f1.STRING_REPEAT - 1 == 6)
+                t1.triggers |= (f1.STRING_REPEAT + 2 + 1 == 7) & (
+                    f1.STRING_REPEAT * 2 - 1 == 6
+                )
 
                 assert (
                     str(t1.triggers.value) == "(((/s/f1:STRING_REPEAT eq 2)"
                     " and (/s/f1:STRING_REPEAT eq 3))"
-                    " or (((/s/f1:STRING_REPEAT + 2) eq 7)"
-                    " and ((/s/f1:STRING_REPEAT - 1) eq 6)))"
+                    " or ((((/s/f1:STRING_REPEAT + 2) + 1) eq 7)"
+                    " and (((/s/f1:STRING_REPEAT * 2) - 1) eq 6)))"
                 )
 
         s.check_definition()
@@ -329,15 +331,15 @@ class TestRepeats:
                 t2.triggers = (f2.ENUMERATED_REPEAT == "7") & (
                     f2.ENUMERATED_REPEAT == 3
                 )
-                t2.triggers |= (f2.ENUMERATED_REPEAT + 2 == 7) & (
-                    f2.ENUMERATED_REPEAT - 1 == 6
+                t2.triggers |= (f2.ENUMERATED_REPEAT + 2 + 1 == 7) & (
+                    f2.ENUMERATED_REPEAT * 2 - 1 == 6
                 )
 
                 assert (
                     str(t2.triggers.value) == "(((/s/f2:ENUMERATED_REPEAT eq 7) and "
                     "(/s/f2:ENUMERATED_REPEAT eq 3)) or "
-                    "(((/s/f2:ENUMERATED_REPEAT + 2) eq 7) and "
-                    "((/s/f2:ENUMERATED_REPEAT - 1) eq 6)))"
+                    "((((/s/f2:ENUMERATED_REPEAT + 2) + 1) eq 7) and "
+                    "(((/s/f2:ENUMERATED_REPEAT * 2) - 1) eq 6)))"
                 )
 
         s.check_definition()
@@ -363,15 +365,15 @@ class TestRepeats:
 
                 t3 = pyflow.Task("t3")
                 t3.triggers = (f3.INTEGER_REPEAT == "7") & (f3.INTEGER_REPEAT == 3)
-                t3.triggers |= (f3.INTEGER_REPEAT + 2 == 7) & (
-                    f3.INTEGER_REPEAT - 1 == 6
+                t3.triggers |= (f3.INTEGER_REPEAT + 2 + 1 == 7) & (
+                    f3.INTEGER_REPEAT * 2 - 1 == 6
                 )
 
                 assert (
                     str(t3.triggers.value) == "(((/s/f3:INTEGER_REPEAT eq 7) and "
                     "(/s/f3:INTEGER_REPEAT eq 3)) or "
-                    "(((/s/f3:INTEGER_REPEAT + 2) eq 7) and "
-                    "((/s/f3:INTEGER_REPEAT - 1) eq 6)))"
+                    "((((/s/f3:INTEGER_REPEAT + 2) + 1) eq 7) and "
+                    "(((/s/f3:INTEGER_REPEAT * 2) - 1) eq 6)))"
                 )
 
         s.check_definition()


### PR DESCRIPTION
### Description
- New class `Mul` in expressions
- New class `BinMatOp`, where composition of math operations is allowed
- Define `__mul__` for `RepeatString`, `RepeatEnumerated` and `RepeatInteger`

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 