### PR TITLE
expose ERROR arguments that can be used in conditional hook/cleanup u…

### DIFF
--- a/pyflow/host.py
+++ b/pyflow/host.py
@@ -457,11 +457,11 @@ class Host:
             export SIGNAL_LIST='%(signal_list)s'
 
             for signal in $SIGNAL_LIST; do
-                trap "rc=\\$?; ERROR $signal \\"Signal $(kill -l $signal) ($signal) received \\"" $signal
+                trap "rc=\\$?; ERROR $signal \\"Signal $(kill -l $signal) ($signal) received\\" \\"\\$rc\\"" $signal
             done
 
             # Trap any calls to exit and errors caught by the -e flag
-            trap 'rc=$?; ERROR EXIT "$rc"' 0
+            trap 'rc=$?; ERROR EXIT "" "$rc"' 0
             set -x
             """) % {"ecf_path": ecflowpath, "signal_list": signal_list})  # noqa: E501
         return script

--- a/pyflow/host.py
+++ b/pyflow/host.py
@@ -437,6 +437,9 @@ class Host:
             set +x
             # Define a error handler
             ERROR() {
+                export EXIT_REASON="$1"
+                export EXIT_DETAIL="$2"
+                export EXIT_RC="${3:-1}"
                 export PATH=%(ecf_path)s:$PATH
                 set +eu  # Clear -eu flag, so we don't fail
                 wait  # wait for background process to stop
@@ -454,11 +457,11 @@ class Host:
             export SIGNAL_LIST='%(signal_list)s'
 
             for signal in $SIGNAL_LIST; do
-                trap "ERROR $signal \\"Signal $(kill -l $signal) ($signal) received \\"" $signal
+                trap "rc=\\$?; ERROR $signal \\"Signal $(kill -l $signal) ($signal) received \\"" $signal
             done
 
             # Trap any calls to exit and errors caught by the -e flag
-            trap ERROR 0
+            trap 'rc=$?; ERROR EXIT "$rc"' 0
             set -x
             """) % {"ecf_path": ecflowpath, "signal_list": signal_list})  # noqa: E501
         return script

--- a/pyflow/nodes.py
+++ b/pyflow/nodes.py
@@ -95,6 +95,25 @@ def _from_json(node, tree):
                     json_build(Task, k, v)
 
 
+def _normalize_exit_hook(hook):
+    if isinstance(hook, str):
+        return [hook]
+    if isinstance(hook, Script):
+        return [hook.value]
+
+    try:
+        hook_items = list(hook)
+    except TypeError as exc:
+        raise TypeError(
+            "exit_hook must be a string, Script, or iterable containing those types"
+        ) from exc
+
+    normalized = []
+    for item in hook_items:
+        normalized.extend(_normalize_exit_hook(item))
+    return normalized
+
+
 class DuplicateNodeError(RuntimeError):
     def __init__(self, parent, new, existing):
         super().__init__(
@@ -937,14 +956,13 @@ class Family(Node):
         super()._add_single_node(node)
 
     def _add_exit_hook(self, hook):
-        if isinstance(hook, str):
-            hook = [hook]
-        for hk in hook:
+        normalized_hook = _normalize_exit_hook(hook)
+        for hk in normalized_hook:
             self._exit_hook.append(hk)
         # Check if properly initialised
         if "_nodes" in self.__dict__:
             for chld in self.executable_children:
-                chld._add_exit_hook(hook)
+                chld._add_exit_hook(normalized_hook)
 
 
 class AnchorFamily(AnchorMixin, Family):
@@ -1202,14 +1220,13 @@ class Suite(AnchorMixin, Node):
         super()._add_single_node(node)
 
     def _add_exit_hook(self, hook):
-        if isinstance(hook, str):
-            hook = [hook]
-        for hk in hook:
+        normalized_hook = _normalize_exit_hook(hook)
+        for hk in normalized_hook:
             self._exit_hook.append(hk)
         # Check if properly initialised
         if "_nodes" in self.__dict__:
             for chld in self.executable_children:
-                chld._add_exit_hook(hook)
+                chld._add_exit_hook(normalized_hook)
 
 
 class Task(Node):
@@ -1399,10 +1416,9 @@ class Task(Node):
 
         return self.host.purge_modules or super().task_purge_modules()
 
-    def _add_exit_hook(self, hook: str):
-        if isinstance(hook, str):
-            hook = [hook]
-        for hk in hook:
+    def _add_exit_hook(self, hook):
+        normalized_hook = _normalize_exit_hook(hook)
+        for hk in normalized_hook:
             self._exit_hook.append(hk)
 
     def generate_script(self):

--- a/tests/test_families.py
+++ b/tests/test_families.py
@@ -165,7 +165,12 @@ def test_exit_hook_scripts():
         "hook_f2_line",
         "hook_t2_line",
     ]
-    assert f3._exit_hook == ["hook_f3_line_1\nhook_f3_line_2", "common_hook_line", "hook_f_line", "hook_f2_line"]
+    assert f3._exit_hook == [
+        "hook_f3_line_1\nhook_f3_line_2",
+        "common_hook_line",
+        "hook_f_line",
+        "hook_f2_line",
+    ]
     assert t3._exit_hook == [
         "hook_f3_line_1\nhook_f3_line_2",
         "hook_t3_line",
@@ -173,7 +178,12 @@ def test_exit_hook_scripts():
         "hook_f_line",
         "hook_f2_line",
     ]
-    assert t4._exit_hook == ["hook_f3_line_1\nhook_f3_line_2", "common_hook_line", "hook_f_line", "hook_f2_line"]
+    assert t4._exit_hook == [
+        "hook_f3_line_1\nhook_f3_line_2",
+        "common_hook_line",
+        "hook_f_line",
+        "hook_f2_line",
+    ]
     assert t5._exit_hook == ["common_hook_line", "hook_f_line"]
 
 
@@ -201,6 +211,7 @@ def test_exit_hook_list_strings_preserves_duplicate_lines():
 
     assert f._exit_hook == expected
     assert t1._exit_hook == expected
+
 
 if __name__ == "__main__":
     from os import path

--- a/tests/test_families.py
+++ b/tests/test_families.py
@@ -1,4 +1,6 @@
-from pyflow import AnchorFamily, Family, Limit, Suite, Task, Variable
+import pytest
+
+from pyflow import AnchorFamily, Family, Limit, Script, Suite, Task, Variable
 
 
 def test_families():
@@ -99,7 +101,7 @@ def test_files_locations():
     assert t7.deploy_path == "/a/base/path/f5/f6/t7.ecf"
 
 
-def test_exit_hook():
+def test_exit_hook_strings():
     """
     Propagate exit hook to children of a given family
     """
@@ -110,7 +112,8 @@ def test_exit_hook():
 
     t5 = Task("t5")
 
-    with Suite("S"):
+    common_hook = "one_hook"
+    with Suite("S", exit_hook=common_hook):
         with Family("f", exit_hook="hook_f", tasks=t5) as f:
             Limit("limit1", 15)
             Variable("VARIABLE1", 1234)
@@ -118,15 +121,86 @@ def test_exit_hook():
             with Family("f2", families=f3, exit_hook="hook_f2") as f2:
                 t2 = Task("t2", exit_hook="hook_t2")
 
-    assert f._exit_hook == ["hook_f"]
-    assert t1._exit_hook == ["hook_f", "hook_t1"]
-    assert f2._exit_hook == ["hook_f", "hook_f2"]
-    assert t2._exit_hook == ["hook_f", "hook_f2", "hook_t2"]
-    assert f3._exit_hook == ["hook_f3", "hook_f", "hook_f2"]
-    assert t3._exit_hook == ["hook_f3", "hook_t3", "hook_f", "hook_f2"]
-    assert t4._exit_hook == ["hook_f3", "hook_f", "hook_f2"]
-    assert t5._exit_hook == ["hook_f"]
+    assert f._exit_hook == [common_hook, "hook_f"]
+    assert t1._exit_hook == [common_hook, "hook_f", "hook_t1"]
+    assert f2._exit_hook == [common_hook, "hook_f", "hook_f2"]
+    assert t2._exit_hook == [common_hook, "hook_f", "hook_f2", "hook_t2"]
+    assert f3._exit_hook == ["hook_f3", common_hook, "hook_f", "hook_f2"]
+    assert t3._exit_hook == ["hook_f3", "hook_t3", common_hook, "hook_f", "hook_f2"]
+    assert t4._exit_hook == ["hook_f3", common_hook, "hook_f", "hook_f2"]
+    assert t5._exit_hook == [common_hook, "hook_f"]
 
+
+def test_exit_hook_scripts():
+    """
+    Support Script objects as exit hooks and propagate to children of a given family
+    """
+    script_hook_f3 = Script(["hook_f3_line_1", "hook_f3_line_2"])
+    script_hook_t3 = Script("hook_t3_line")
+    with Family("f3", exit_hook=script_hook_f3) as f3:
+        t3 = Task("t3", exit_hook=script_hook_t3)
+        t4 = Task("t4")
+
+    t5 = Task("t5")
+
+    common_hook = Script("common_hook_line")
+    hook_f = Script("hook_f_line")
+    hook_t1 = Script("hook_t1_line")
+    hook_f2 = Script("hook_f2_line")
+    hook_t2 = Script("hook_t2_line")
+    with Suite("S", exit_hook=common_hook):
+        with Family("f", exit_hook=hook_f, tasks=t5) as f:
+            Limit("limit1", 15)
+            Variable("VARIABLE1", 1234)
+            t1 = Task("t1", exit_hook=hook_t1)
+            with Family("f2", families=f3, exit_hook=hook_f2) as f2:
+                t2 = Task("t2", exit_hook=hook_t2)
+
+    assert f._exit_hook == ["common_hook_line", "hook_f_line"]
+    assert t1._exit_hook == ["common_hook_line", "hook_f_line", "hook_t1_line"]
+    assert f2._exit_hook == ["common_hook_line", "hook_f_line", "hook_f2_line"]
+    assert t2._exit_hook == [
+        "common_hook_line",
+        "hook_f_line",
+        "hook_f2_line",
+        "hook_t2_line",
+    ]
+    assert f3._exit_hook == ["hook_f3_line_1\nhook_f3_line_2", "common_hook_line", "hook_f_line", "hook_f2_line"]
+    assert t3._exit_hook == [
+        "hook_f3_line_1\nhook_f3_line_2",
+        "hook_t3_line",
+        "common_hook_line",
+        "hook_f_line",
+        "hook_f2_line",
+    ]
+    assert t4._exit_hook == ["hook_f3_line_1\nhook_f3_line_2", "common_hook_line", "hook_f_line", "hook_f2_line"]
+    assert t5._exit_hook == ["common_hook_line", "hook_f_line"]
+
+
+@pytest.mark.xfail(
+    reason="Known issue: duplicate list exit_hook lines are de-duplicated when inherited"
+)
+def test_exit_hook_list_strings_preserves_duplicate_lines():
+    """
+    Lists of string exit hooks should preserve ordering and duplicate lines.
+    """
+
+    parent_lines = ["echo pre_cleanup", "echo duplicate_line"]
+    child_lines = ["echo duplicate_line", "echo post_cleanup"]
+
+    with Suite("S", exit_hook=parent_lines):
+        with Family("f", exit_hook=child_lines) as f:
+            t1 = Task("t1")
+
+    expected = [
+        "echo pre_cleanup",
+        "echo duplicate_line",
+        "echo duplicate_line",
+        "echo post_cleanup",
+    ]
+
+    assert f._exit_hook == expected
+    assert t1._exit_hook == expected
 
 if __name__ == "__main__":
     from os import path

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -446,6 +446,16 @@ def test_traps():
     assert signal_list1 in s1
     assert signal_list2 in s2
 
+    # Ensure ERROR exposes contract variables used by custom exit hooks.
+    assert 'export EXIT_REASON="$1"' in s1
+    assert 'export EXIT_DETAIL="$2"' in s1
+    assert 'export EXIT_RC="${3:-1}"' in s1
+
+    # Ensure traps pass the command return code through to ERROR.
+    assert 'trap "rc=\\$?; ERROR $signal' in s1
+    assert '\\"\\$rc\\"" $signal' in s1
+    assert 'trap \'rc=$?; ERROR EXIT "" "$rc"\' 0' in s1
+
 
 @pytest.mark.parametrize(
     "key,expected_class,kwargs",


### PR DESCRIPTION
### Description

This pull request updates the error handling logic in the shell script generated by the `preamble_error_function` in `pyflow/host.py`. The main focus is to improve the way exit reasons, details, and return codes are captured and exported when errors or signals are trapped.

**Improvements to error handling and signal trapping:**

* The `ERROR` handler now exports three variables: `EXIT_REASON`, `EXIT_DETAIL`, and `EXIT_RC`, providing more detailed context for errors and exits.
* Signal traps now capture the return code (`rc=$?`) before invoking the `ERROR` handler, ensuring accurate reporting of the exit status when a signal is received.
* The trap for exit (`trap 0`) is updated to pass the exit code to the `ERROR` handler, improving the accuracy of exit reporting.
* This allows user custom `exit_hook` implementations that have conditional paths depending on task exit status. `exit_hook` is currently the only supported injection point for custom cleanup/post-execution logic

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
